### PR TITLE
Rotate images

### DIFF
--- a/FoGSE/demos/demo_single_existing_cdte.py
+++ b/FoGSE/demos/demo_single_existing_cdte.py
@@ -3,7 +3,7 @@ A demo to walk through an existing CdTe raw file.
 """
 import os
 
-from PyQt6.QtWidgets import QApplication
+from PyQt6.QtWidgets import QApplication, QWidget, QGridLayout
 
 from FoGSE.demos.readRawToRefined_single_cdte import CdTeFileReader
 from FoGSE.windows.CdTewindow import CdTeWindow
@@ -22,6 +22,13 @@ if __name__=="__main__":
     f1.set_fade_out(5)
     f1.set_image_colour("red")
 
-    f0.show()
-    f1.show()
+    f2 = CdTeWindow(reader=reader, plotting_product="image", image_angle=30)
+    f2.set_image_colour("red")
+
+    w = QWidget()
+    lay = QGridLayout(w)
+    lay.addWidget(f0, 1, 0)
+    lay.addWidget(f1, 0, 0)
+    lay.addWidget(f2, 0, 1)
+    w.show()
     app.exec()

--- a/FoGSE/demos/demo_single_existing_cdte.py
+++ b/FoGSE/demos/demo_single_existing_cdte.py
@@ -30,5 +30,6 @@ if __name__=="__main__":
     lay.addWidget(f0, 1, 0)
     lay.addWidget(f1, 0, 0)
     lay.addWidget(f2, 0, 1)
+    w.resize(1600,1000)
     w.show()
     app.exec()

--- a/FoGSE/demos/readRawToRefined_single_cdte.py
+++ b/FoGSE/demos/readRawToRefined_single_cdte.py
@@ -3,6 +3,7 @@ Reader for an existing raw CdTe data file.
 """
 
 import struct
+import numpy as np
 
 from FoGSE.demos.CdTerawalldata2parser_existingFile import CdTerawalldata2parser_existingFile
 from FoGSE.parsers.CdTeframeparser import CdTerawdataframe2parser
@@ -89,7 +90,7 @@ class CdTeFileReader(ReaderBase):
         except ValueError:
             # no data from parser so pass nothing on with a time of -1
             print("No data from parser.")
-            flags, event_df, all_hkdicts = (None,{'ti':-1},None)
+            flags, event_df, all_hkdicts = (None,{'ti':np.array([-1])},None)
         return flags, event_df, all_hkdicts
     
     def parsed_2_collection(self, parsed_data):

--- a/FoGSE/windows/CdTewindow.py
+++ b/FoGSE/windows/CdTewindow.py
@@ -11,6 +11,7 @@ import pyqtgraph as pg
 from FoGSE.read_raw_to_refined.readRawToRefinedCdTe import CdTeReader
 from FoGSE.demos.readRawToRefined_single_cdte import CdTeFileReader
 from FoGSE.visualization import DetectorPlotView
+from FoGSE.windows.images import rotatation
 
 
 class CdTeWindow(DetectorPlotView):
@@ -32,7 +33,7 @@ class CdTeWindow(DetectorPlotView):
         String to determine whether an "image" and or "spectrogram" should be shown.
         Default: "image"
     """
-    def __init__(self, data_file=None, reader=None, plotting_product="image", parent=None, name="CdTe"):
+    def __init__(self, data_file=None, reader=None, plotting_product="image", image_angle=0, parent=None, name="CdTe"):
 
         DetectorPlotView.__init__(self, parent, name)
 
@@ -45,6 +46,9 @@ class CdTeWindow(DetectorPlotView):
             self.reader = reader
         else:
             print("How do I read the CdTe data?")
+
+        #make this available everywhere, incase a rotation is specified for the image
+        self.image_angle = image_angle
             
         self.image_product = plotting_product
         if self.image_product in ["image", "spectrogram"]:
@@ -71,7 +75,9 @@ class CdTeWindow(DetectorPlotView):
 
         # create QImage from numpy array 
         if self.image_product=="image":
-            self.detw, self.deth = 128, 128
+            # could do some maths to figure out but this WILL give the result need even if something is changed elsewhere
+            _rm = rotatation.rotate_matrix(matrix=np.zeros((128, 128)), angle=self.image_angle)
+            self.detw, self.deth = np.shape(_rm)
             # set title and labels
             self.set_labels(self.graphPane, xlabel="X", ylabel="Y", title="Image")
         elif self.image_product=="spectrogram":
@@ -88,6 +94,11 @@ class CdTeWindow(DetectorPlotView):
         self.graphPane.addItem(self.img)
 
         self.set_image_colour("green")
+
+    def update_rotation(self, image_angle):
+        """ Allow the image rotation to be updated whenever. """
+        self.image_angle = image_angle
+        self.setup_2d()
 
     def set_fade_out(self, no_of_frames):
         """ Define how many frames to fade a count out over. """
@@ -120,7 +131,8 @@ class CdTeWindow(DetectorPlotView):
         
         # get the new frame
         if self.image_product=="image":
-            new_frame = self.reader.collection.image_array(area_correction=False)
+            new_frame_orig = self.reader.collection.image_array(area_correction=False)
+            new_frame = rotatation.rotate_matrix(matrix=new_frame_orig, angle=self.image_angle)
             self.update_method = "fade"
         elif self.image_product=="spectrogram":
             new_frame = self.reader.collection.spectrogram_array(remap=True, 

--- a/FoGSE/windows/CdTewindow.py
+++ b/FoGSE/windows/CdTewindow.py
@@ -89,6 +89,8 @@ class CdTeWindow(DetectorPlotView):
         self.set_image_ndarray()
         q_image = pg.QtGui.QImage(self.my_array, self.detw, self.deth, self.cformat)
 
+        if hasattr(self,"img"):
+            self.graphPane.removeItem(self.img)
         # send image to frame and add to plot
         self.img = QtWidgets.QGraphicsPixmapItem(pg.QtGui.QPixmap(q_image))
         self.graphPane.addItem(self.img)

--- a/FoGSE/windows/CdTewindow.py
+++ b/FoGSE/windows/CdTewindow.py
@@ -131,8 +131,9 @@ class CdTeWindow(DetectorPlotView):
         
         # get the new frame
         if self.image_product=="image":
-            new_frame_orig = self.reader.collection.image_array(area_correction=False)
-            new_frame = rotatation.rotate_matrix(matrix=new_frame_orig, angle=self.image_angle)
+            new_frame = self.reader.collection.image_array(area_correction=False)
+            new_frame = rotatation.rotate_matrix(matrix=new_frame, angle=self.image_angle)
+            new_frame[new_frame<1e-1] = 0 # because interp 0s causes tiny artifacts
             self.update_method = "fade"
         elif self.image_product=="spectrogram":
             new_frame = self.reader.collection.spectrogram_array(remap=True, 

--- a/FoGSE/windows/CdTewindow.py
+++ b/FoGSE/windows/CdTewindow.py
@@ -47,7 +47,7 @@ class CdTeWindow(DetectorPlotView):
         else:
             print("How do I read the CdTe data?")
 
-        #make this available everywhere, incase a rotation is specified for the image
+        # make this available everywhere, incase a rotation is specified for the image
         self.image_angle = image_angle
             
         self.image_product = plotting_product

--- a/FoGSE/windows/QLCMOSwindow.py
+++ b/FoGSE/windows/QLCMOSwindow.py
@@ -5,11 +5,12 @@ A demo to walk through an existing CMOS raw file.
 import numpy as np
 
 from PyQt6 import QtCore, QtWidgets
-from PyQt6.QtWidgets import QApplication, QWidget, QVBoxLayout
+from PyQt6.QtWidgets import QApplication, QWidget, QGridLayout
 import pyqtgraph as pg
 
 from FoGSE.read_raw_to_refined.readRawToRefinedQLCMOS import QLCMOSReader
 from FoGSE.visualization import DetectorPlotView
+from FoGSE.windows.images import rotatation
 
 
 class QLCMOSWindow(DetectorPlotView):
@@ -31,7 +32,7 @@ class QLCMOSWindow(DetectorPlotView):
         String to determine whether an "image" and or <something else> should be shown.
         Default: "image"
     """
-    def __init__(self, data_file=None, reader=None, plotting_product="image", parent=None, name="CMOS"):
+    def __init__(self, data_file=None, reader=None, plotting_product="image", image_angle=0, parent=None, name="CMOS"):
 
         DetectorPlotView.__init__(self, parent, name)
 
@@ -44,6 +45,9 @@ class QLCMOSWindow(DetectorPlotView):
             self.reader = reader
         else:
             print("How do I read the CMOS data?")
+
+        # make this available everywhere, incase a rotation is specified for the image
+        self.image_angle = image_angle
             
         self.image_product = plotting_product
         if self.image_product in ["image"]:
@@ -70,7 +74,10 @@ class QLCMOSWindow(DetectorPlotView):
 
         # create QImage from numpy array 
         if self.image_product=="image":
-            self.detw, self.deth = 512, 480
+            # could do some maths to figure out but this WILL give the result need even if something is changed elsewhere
+            _rm = rotatation.rotate_matrix(matrix=np.zeros((512, 480)), angle=self.image_angle)
+            self.detw, self.deth = np.shape(_rm)
+            # self.detw, self.deth = 512, 480
             # set title and labels
             self.set_labels(self.graphPane, xlabel="X", ylabel="Y", title="Image")
 
@@ -78,10 +85,17 @@ class QLCMOSWindow(DetectorPlotView):
         self.set_image_ndarray()
         q_image = pg.QtGui.QImage(self.my_array, self.detw, self.deth, self.cformat)
 
+        if hasattr(self,"img"):
+            self.graphPane.removeItem(self.img)
         # send image to frame and add to plot
         self.img = QtWidgets.QGraphicsPixmapItem(pg.QtGui.QPixmap(q_image))
         self.graphPane.addItem(self.img)
         self.set_image_colour("red")
+
+    def update_rotation(self, image_angle):
+        """ Allow the image rotation to be updated whenever. """
+        self.image_angle = image_angle
+        self.setup_2d()
 
     def set_fade_out(self, no_of_frames):
         """ Define how many frames to fade a count out over. """
@@ -115,6 +129,8 @@ class QLCMOSWindow(DetectorPlotView):
         # get the new frame
         if self.image_product=="image":
             new_frame = self.reader.collection.image_array()
+            new_frame = rotatation.rotate_matrix(matrix=new_frame, angle=self.image_angle)
+            new_frame[new_frame<1e-1] = 0 # because interp 0s causes tiny artifacts
             self.update_method = "replace"
 
         # update current plotted data with new frame
@@ -274,8 +290,12 @@ if __name__=="__main__":
     reader = QLCMOSReader(datafile)
 
     f0 = QLCMOSWindow(reader=reader, plotting_product="image")
-    # f1 = CMOSWindow(reader=reader, plotting_product="image")
-    # print(R.collections)
-    f0.show()
-    # f1.show()
+    f1 = QLCMOSWindow(reader=reader, plotting_product="image", image_angle=-10)
+
+    w = QWidget()
+    lay = QGridLayout(w)
+    lay.addWidget(f0, 0, 0)
+    lay.addWidget(f1, 0, 1)
+    w.resize(1200,500)
+    w.show()
     app.exec()

--- a/FoGSE/windows/images/rotatation.py
+++ b/FoGSE/windows/images/rotatation.py
@@ -1,0 +1,34 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.ndimage import rotate
+
+def rotate_matrix(matrix, angle):
+    """ 
+    Rotates a matrix by a given angle.
+    
+    Parameters
+    ----------
+    matrix : `numpy.ndarray`
+            The matrix representing an image.
+
+    angle : `int`, `float`
+            In degrees, the angle to rotate anti-clockwise.
+
+    Returns
+    -------
+    `numpy.ndarray` : 
+            The newly rotated image where the number of pixels has been 
+            increased to accomodate the rotation
+    """
+    return rotate(matrix, angle=angle)
+
+if __name__=="__main__":
+    x = np.random.randint(1, 256, size=[100, 100, 3])/256
+    rotated = rotate(x, angle=45)
+    rotated1 = rotate(x, angle=10)
+
+    fig, axs = plt.subplots(1,3)
+    axs[0].imshow(x)
+    axs[1].imshow(rotated1)
+    axs[2].imshow(rotated)
+    plt.show()

--- a/FoGSE/windows/images/rotatation.py
+++ b/FoGSE/windows/images/rotatation.py
@@ -12,7 +12,8 @@ def rotate_matrix(matrix, angle):
             The matrix representing an image.
 
     angle : `int`, `float`
-            In degrees, the angle to rotate anti-clockwise.
+            In degrees, the angle to rotate clockwise (+ve is clockwise, 
+            and -ve is anti-clockwise).
 
     Returns
     -------

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ setuptools.setup(
     install_requires=[
             "numpy", 
             "PyQt6", 
-            "pyqtgraph"
+            "pyqtgraph",
+            "scipy"
         ],
     packages=setuptools.find_packages(),
     zip_safe=False


### PR DESCRIPTION
CdTe and CMOS plotted images should now be able to rotate to the enjoyment of all. Also added `scipy` as a dependency of the package since its rotation method seems to be the one to go with.