### PR TITLE
Use json

### DIFF
--- a/FoGSE/collections/CdTeCollection.py
+++ b/FoGSE/collections/CdTeCollection.py
@@ -7,6 +7,8 @@ from copy import copy
 import numpy as np
 import matplotlib.pyplot as plt
 
+from FoGSE.utils import get_system_value
+# get_system_value("gse", "display_settings", "cdte", "pc", "collections", "read_interval")
 
 class CdTeCollection:
     """

--- a/FoGSE/collections/CdTeCollection.py
+++ b/FoGSE/collections/CdTeCollection.py
@@ -8,7 +8,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from FoGSE.utils import get_system_value
-# get_system_value("gse", "display_settings", "cdte", "pc", "collections", "read_interval")
 
 class CdTeCollection:
     """
@@ -734,7 +733,7 @@ class CdTeCollection:
     def delta_time(self):
         """ Get the delta-t of the frame. """
         # not using_unixtime = (np.max(self.event_dataframe['unixtime'])-np.min(self.event_dataframe['unixtime'])) anymore
-        ti_clock_interval = 1/10.24e6# 10.24e-6 # 10.24 usec -> 10.24 change in `ti`` every usec?`
+        ti_clock_interval = get_system_value("gse", "display_settings", "cdte", "pc", "collections", "ti_clock_interval")# 10.24e-6 # 10.24 usec -> 10.24 change in `ti`` every usec?`
         _ti_time = (np.max(self.event_dataframe['ti'])-np.min(self.event_dataframe['ti']))
         return _ti_time*ti_clock_interval
         

--- a/FoGSE/read_raw_to_refined/readRawToRefinedBase.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedBase.py
@@ -29,6 +29,19 @@ from PyQt6.QtWidgets import QWidget
 # for example `from FoGSE.parsers.CdTeparser import CdTerawalldata2parser`
 # for example from `FoGSE.collections.CdTeCollection import CdTeCollection`
 
+# import json
+# from FoGSE.utils import get_system_dict
+# FILE_DIR = os.path.dirname(os.path.realpath(__file__))
+# json_config_file = FILE_DIR+"/../../foxsi4-commands/systems.json"
+# with open(json_config_file, "r") as json_config:
+#     json_dict = json.load(json_config)
+
+#     BYTES = int(get_system_dict("cdte1",json_dict)["spacewire_interface"]["ring_buffer_interface"]["pc"]["ring_frame_size_bytes"], 16)
+
+# # {"cdte_pc":["cdte1", "spacewire_interface", "ring_buffer_interface", "pc", "ring_frame_size_bytes"]}
+
+def get_frame_size():
+    pass
 
 class ReaderBase(QWidget):
     """
@@ -65,7 +78,7 @@ class ReaderBase(QWidget):
 
         # default is update plot every 100 ms
         self.call_interval()
-        # read 50,000 bytes from the end of `self.data_file` at a time
+        # read 25,000 bytes from the end of `self.data_file` at a time
         self.define_buffer_size(size=25_000)
 
         self.setup_and_start_timer()

--- a/FoGSE/read_raw_to_refined/readRawToRefinedBase.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedBase.py
@@ -19,50 +19,15 @@ One class is assigned to do both jobs since (at this time) we will always want t
 binary data to a collected, human readable form for investigation and analysis.
 """
 
-import json
 import os
 
 from PyQt6 import QtCore
 from PyQt6.QtWidgets import QWidget
 
-from FoGSE.utils import get_system_dict, get_ring_buffer_interface
-
 # import parser for `extract_raw_data` and `extract_raw_data_<det>`
 # import collection for `parsed_2_collections`
 # for example `from FoGSE.parsers.CdTeparser import CdTerawalldata2parser`
 # for example from `FoGSE.collections.CdTeCollection import CdTeCollection`
-
-
-def get_frame_size(system, product):
-    """
-    Method to retreive the "ring_frame_size_bytes" value for a given `system` 
-    (e.g., cdte1, cmos1, etc.) and `product` (e.g., pc, hk, etc.).
-
-    Parameters
-    ----------
-    system : `str`
-        The system of interest (e.g., cdte1, cmos1, etc.).
-
-    product : `str`
-        The system's product of interest (e.g., pc, hk, etc.).
-
-    Example
-    -------
-    >>> get_frame_size("cdte1", "pc")
-
-    32780 # the number of bytes to a cdte1_pc frame in the ring buffer
-
-    # same as running:
-    # int(get_system_dict("cdte1",json_dict)["spacewire_interface"]["ring_buffer_interface"]["pc"]["ring_frame_size_bytes"], 16)
-    """
-    # get the JSON file with all settings
-    FILE_DIR = os.path.dirname(os.path.realpath(__file__))
-    json_config_file = os.path.join(FILE_DIR, "..", "..", "foxsi4-commands", "systems.json")
-
-    # open the JSON file and find the system's product byte size
-    with open(json_config_file, "r") as json_config:
-        json_dict = json.load(json_config)
-        return int(get_ring_buffer_interface(get_system_dict(system,json_dict))[product]["ring_frame_size_bytes"], 16)
 
 class ReaderBase(QWidget):
     """

--- a/FoGSE/read_raw_to_refined/readRawToRefinedBase.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedBase.py
@@ -19,29 +19,50 @@ One class is assigned to do both jobs since (at this time) we will always want t
 binary data to a collected, human readable form for investigation and analysis.
 """
 
+import json
 import os
 
 from PyQt6 import QtCore
 from PyQt6.QtWidgets import QWidget
+
+from FoGSE.utils import get_system_dict, get_ring_buffer_interface
 
 # import parser for `extract_raw_data` and `extract_raw_data_<det>`
 # import collection for `parsed_2_collections`
 # for example `from FoGSE.parsers.CdTeparser import CdTerawalldata2parser`
 # for example from `FoGSE.collections.CdTeCollection import CdTeCollection`
 
-# import json
-# from FoGSE.utils import get_system_dict
-# FILE_DIR = os.path.dirname(os.path.realpath(__file__))
-# json_config_file = FILE_DIR+"/../../foxsi4-commands/systems.json"
-# with open(json_config_file, "r") as json_config:
-#     json_dict = json.load(json_config)
 
-#     BYTES = int(get_system_dict("cdte1",json_dict)["spacewire_interface"]["ring_buffer_interface"]["pc"]["ring_frame_size_bytes"], 16)
+def get_frame_size(system, product):
+    """
+    Method to retreive the "ring_frame_size_bytes" value for a given `system` 
+    (e.g., cdte1, cmos1, etc.) and `product` (e.g., pc, hk, etc.).
 
-# # {"cdte_pc":["cdte1", "spacewire_interface", "ring_buffer_interface", "pc", "ring_frame_size_bytes"]}
+    Parameters
+    ----------
+    system : `str`
+        The system of interest (e.g., cdte1, cmos1, etc.).
 
-def get_frame_size():
-    pass
+    product : `str`
+        The system's product of interest (e.g., pc, hk, etc.).
+
+    Example
+    -------
+    >>> get_frame_size("cdte1", "pc")
+
+    32780 # the number of bytes to a cdte1_pc frame in the ring buffer
+
+    # same as running:
+    # int(get_system_dict("cdte1",json_dict)["spacewire_interface"]["ring_buffer_interface"]["pc"]["ring_frame_size_bytes"], 16)
+    """
+    # get the JSON file with all settings
+    FILE_DIR = os.path.dirname(os.path.realpath(__file__))
+    json_config_file = os.path.join(FILE_DIR, "..", "..", "foxsi4-commands", "systems.json")
+
+    # open the JSON file and find the system's product byte size
+    with open(json_config_file, "r") as json_config:
+        json_dict = json.load(json_config)
+        return int(get_ring_buffer_interface(get_system_dict(system,json_dict))[product]["ring_frame_size_bytes"], 16)
 
 class ReaderBase(QWidget):
     """

--- a/FoGSE/read_raw_to_refined/readRawToRefinedCMOSHK.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedCMOSHK.py
@@ -6,7 +6,7 @@ Can read:
     * CMOS PC
 """
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
 
 from FoGSE.readBackwards import BackwardsReader
 import FoGSE.parsers.CMOSparser as cmosp
@@ -29,8 +29,8 @@ class CMOSHKReader(ReaderBase):
             return
         
         ReaderBase.__init__(self, datafile, parent)
-        # The magic number for CMOS PC data is 590,848. The magic number for CMOS QL data is 492,544.
-        self.define_buffer_size(size=536)
+        
+        self.define_buffer_size(size=get_frame_size("cmos1", "hk")) # 536 bytes
         self.call_interval(100)
 
     def extract_raw_data(self):

--- a/FoGSE/read_raw_to_refined/readRawToRefinedCMOSHK.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedCMOSHK.py
@@ -6,12 +6,12 @@ Can read:
     * CMOS PC
 """
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
 
 from FoGSE.readBackwards import BackwardsReader
 import FoGSE.parsers.CMOSparser as cmosp
 from FoGSE.collections.CMOSHKCollection import CMOSHKCollection
-
+from FoGSE.utils import get_frame_size, get_system_value
 
 class CMOSHKReader(ReaderBase):
     """
@@ -31,7 +31,7 @@ class CMOSHKReader(ReaderBase):
         ReaderBase.__init__(self, datafile, parent)
         
         self.define_buffer_size(size=get_frame_size("cmos1", "hk")) # 536 bytes
-        self.call_interval(100)
+        self.call_interval(get_system_value("gse", "display_settings", "cmos", "hk", "read_raw_to_refined", "read_interval"))
 
     def extract_raw_data(self):
         """

--- a/FoGSE/read_raw_to_refined/readRawToRefinedCMOSPC.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedCMOSPC.py
@@ -6,12 +6,12 @@ Can read:
     * CMOS PC
 """
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
 
 from FoGSE.readBackwards import BackwardsReader
 from FoGSE.parsers.CMOSparser import PCimageData
 from FoGSE.collections.CMOSPCCollection import CMOSPCCollection
-
+from FoGSE.utils import get_frame_size, get_system_value
 
 class CMOSPCReader(ReaderBase):
     """
@@ -27,7 +27,7 @@ class CMOSPCReader(ReaderBase):
         ReaderBase.__init__(self, datafile, parent)
         # The magic number for CMOS PC data is 590,848. The magic number for CMOS QL data is 492,544.
         self.define_buffer_size(size=get_frame_size("cmos1", "pc"))
-        self.call_interval(100)
+        self.call_interval(get_system_value("gse", "display_settings", "cmos", "pc", "read_raw_to_refined", "read_interval"))
 
     def extract_raw_data(self):
         """

--- a/FoGSE/read_raw_to_refined/readRawToRefinedCMOSPC.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedCMOSPC.py
@@ -6,7 +6,7 @@ Can read:
     * CMOS PC
 """
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
 
 from FoGSE.readBackwards import BackwardsReader
 from FoGSE.parsers.CMOSparser import PCimageData
@@ -26,7 +26,7 @@ class CMOSPCReader(ReaderBase):
         """
         ReaderBase.__init__(self, datafile, parent)
         # The magic number for CMOS PC data is 590,848. The magic number for CMOS QL data is 492,544.
-        self.define_buffer_size(size=590_848)
+        self.define_buffer_size(size=get_frame_size("cmos1", "pc"))
         self.call_interval(100)
 
     def extract_raw_data(self):

--- a/FoGSE/read_raw_to_refined/readRawToRefinedCMOSQL.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedCMOSQL.py
@@ -6,12 +6,12 @@ Can read:
     * CMOS
 """
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
 
 from FoGSE.readBackwards import BackwardsReader
 from FoGSE.parsers.CMOSparser import QLimageData 
 from FoGSE.collections.CMOSQLCollection import CMOSQLCollection
-
+from FoGSE.utils import get_frame_size, get_system_value
 
 class CMOSQLReader(ReaderBase):
     """
@@ -27,7 +27,7 @@ class CMOSQLReader(ReaderBase):
         ReaderBase.__init__(self, datafile, parent)
         # The magic number for CMOS PC data is 590,848. The magic number for CMOS QL data is 492,544.
         self.define_buffer_size(size=get_frame_size("cmos1", "ql"))
-        self.call_interval(100)
+        self.call_interval(get_system_value("gse", "display_settings", "cmos", "ql", "read_raw_to_refined", "read_interval"))
 
     def extract_raw_data(self):
         """

--- a/FoGSE/read_raw_to_refined/readRawToRefinedCMOSQL.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedCMOSQL.py
@@ -6,7 +6,7 @@ Can read:
     * CMOS
 """
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
 
 from FoGSE.readBackwards import BackwardsReader
 from FoGSE.parsers.CMOSparser import QLimageData 
@@ -26,7 +26,7 @@ class CMOSQLReader(ReaderBase):
         """
         ReaderBase.__init__(self, datafile, parent)
         # The magic number for CMOS PC data is 590,848. The magic number for CMOS QL data is 492,544.
-        self.define_buffer_size(size=492_544)
+        self.define_buffer_size(size=get_frame_size("cmos1", "ql"))
         self.call_interval(100)
 
     def extract_raw_data(self):

--- a/FoGSE/read_raw_to_refined/readRawToRefinedCdTe.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedCdTe.py
@@ -10,12 +10,13 @@ import struct
 import numpy as np
 import os
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
 
 from FoGSE.readBackwards import BackwardsReader
 from FoGSE.parsers.CdTeparser import CdTerawalldata2parser
 from FoGSE.parsers.CdTeframeparser import CdTerawdataframe2parser
 from FoGSE.collections.CdTeCollection import CdTeCollection
+from FoGSE.utils import get_frame_size, get_system_value
 
 class CdTeReader(ReaderBase):
     """
@@ -31,7 +32,7 @@ class CdTeReader(ReaderBase):
         ReaderBase.__init__(self, datafile, parent)
         
         self.define_buffer_size(size=get_frame_size("cdte1", "pc")) # 32_780 bytes
-        self.call_interval(100)
+        self.call_interval(get_system_value("gse", "display_settings", "cdte", "pc", "read_raw_to_refined", "read_interval"))
 
     def extract_raw_data(self):
         """

--- a/FoGSE/read_raw_to_refined/readRawToRefinedCdTe.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedCdTe.py
@@ -30,8 +30,7 @@ class CdTeReader(ReaderBase):
         """
         ReaderBase.__init__(self, datafile, parent)
         
-        # want something like, self.define_buffer_size(size=get_frame_size("cdte_pc")) 
-        self.define_buffer_size(size=32_780)#100_000#32_780
+        self.define_buffer_size(size=get_frame_size("cdte1", "pc")) # 32_780 bytes
         self.call_interval(100)
 
     def extract_raw_data(self):

--- a/FoGSE/read_raw_to_refined/readRawToRefinedCdTe.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedCdTe.py
@@ -10,24 +10,12 @@ import struct
 import numpy as np
 import os
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
 
 from FoGSE.readBackwards import BackwardsReader
 from FoGSE.parsers.CdTeparser import CdTerawalldata2parser
 from FoGSE.parsers.CdTeframeparser import CdTerawdataframe2parser
 from FoGSE.collections.CdTeCollection import CdTeCollection
-
-import json
-from FoGSE.utils import get_system_dict
-
-FILE_DIR = os.path.dirname(os.path.realpath(__file__))
-json_config_file = FILE_DIR+"/../../foxsi4-commands/systems.json"
-with open(json_config_file, "r") as json_config:
-    json_dict = json.load(json_config)
-
-    BYTES = int(get_system_dict("cdte1",json_dict)["spacewire_interface"]["ring_buffer_interface"]["pc"]["ring_frame_size_bytes"], 16)
-
-# {"cdte_pc":["cdte1", "spacewire_interface", "ring_buffer_interface", "pc", "ring_frame_size_bytes"]}
 
 class CdTeReader(ReaderBase):
     """
@@ -41,9 +29,9 @@ class CdTeReader(ReaderBase):
         Collected : organised by intrumentation
         """
         ReaderBase.__init__(self, datafile, parent)
-        print(BYTES)
-
-        self.define_buffer_size(size=BYTES)#100_000#32_780
+        
+        # want something like, self.define_buffer_size(size=get_frame_size("cdte_pc")) 
+        self.define_buffer_size(size=32_780)#100_000#32_780
         self.call_interval(100)
 
     def extract_raw_data(self):

--- a/FoGSE/read_raw_to_refined/readRawToRefinedCdTeHK.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedCdTeHK.py
@@ -9,7 +9,7 @@ Can read:
 import struct
 import numpy as np
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
 
 from FoGSE.readBackwards import BackwardsReader
 from FoGSE.parsers.CdTeparser import CdTecanisterhkparser
@@ -34,7 +34,7 @@ class CdTeHKReader(ReaderBase):
 
         ReaderBase.__init__(self, datafile, parent)
 
-        self.define_buffer_size(size=796)#100_000#32_780
+        self.define_buffer_size(size=get_frame_size("cdte1", "hk")) # 796 bytes
         self.call_interval(100)
 
     def extract_raw_data(self):

--- a/FoGSE/read_raw_to_refined/readRawToRefinedCdTeHK.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedCdTeHK.py
@@ -9,13 +9,13 @@ Can read:
 import struct
 import numpy as np
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
 
 from FoGSE.readBackwards import BackwardsReader
 from FoGSE.parsers.CdTeparser import CdTecanisterhkparser
 # from FoGSE.parsers.CdTeframeparser import CdTerawdataframe2parser
 from FoGSE.collections.CdTeHKCollection import CdTeHKCollection
-
+from FoGSE.utils import get_frame_size, get_system_value
 
 class CdTeHKReader(ReaderBase):
     """
@@ -35,7 +35,7 @@ class CdTeHKReader(ReaderBase):
         ReaderBase.__init__(self, datafile, parent)
 
         self.define_buffer_size(size=get_frame_size("cdte1", "hk")) # 796 bytes
-        self.call_interval(100)
+        self.call_interval(get_system_value("gse", "display_settings", "cdte", "hk", "read_raw_to_refined", "read_interval"))
 
     def extract_raw_data(self):
         """

--- a/FoGSE/read_raw_to_refined/readRawToRefinedDE.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedDE.py
@@ -9,13 +9,13 @@ Can read:
 import struct
 import numpy as np
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
 
 from FoGSE.readBackwards import BackwardsReader
 from FoGSE.parsers.CdTeparser import CdTedehkparser
 # from FoGSE.parsers.CdTeframeparser import CdTerawdataframe2parser
 from FoGSE.collections.DECollection import DECollection
-
+from FoGSE.utils import get_frame_size, get_system_value
 
 class DEReader(ReaderBase):
     """
@@ -35,7 +35,7 @@ class DEReader(ReaderBase):
         ReaderBase.__init__(self, datafile, parent)
         
         self.define_buffer_size(size=get_frame_size("cdtede", "hk")) # 32 bytes
-        self.call_interval(100)
+        self.call_interval(get_system_value("gse", "display_settings", "cdtede", "hk", "read_raw_to_refined", "read_interval"))
 
     def extract_raw_data(self):
         """

--- a/FoGSE/read_raw_to_refined/readRawToRefinedDE.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedDE.py
@@ -9,7 +9,7 @@ Can read:
 import struct
 import numpy as np
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
 
 from FoGSE.readBackwards import BackwardsReader
 from FoGSE.parsers.CdTeparser import CdTedehkparser
@@ -33,8 +33,8 @@ class DEReader(ReaderBase):
             return
 
         ReaderBase.__init__(self, datafile, parent)
-
-        self.define_buffer_size(size=32)#100_000#32_780
+        
+        self.define_buffer_size(size=get_frame_size("cdtede", "hk")) # 32 bytes
         self.call_interval(100)
 
     def extract_raw_data(self):

--- a/FoGSE/read_raw_to_refined/readRawToRefinedPower.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedPower.py
@@ -5,7 +5,7 @@ the RTDs
 
 # `from PyQt6 import QtCore`
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
 
 from FoGSE.readBackwards import BackwardsReader
 from FoGSE.parsers.Powerparser import adcparser
@@ -14,7 +14,7 @@ from FoGSE.collections.PowerCollection import PowerCollection
 
 class PowerReader(ReaderBase):
     """
-    Reader for the RTD readout.
+    Reader for the Power readout.
     """
 
     def __init__(self, datafile, parent=None):
@@ -24,8 +24,8 @@ class PowerReader(ReaderBase):
         Collected : organised by intrumentation
         """
         ReaderBase.__init__(self, datafile, parent)
-
-        self.define_buffer_size(size=38)
+        
+        self.define_buffer_size(size=get_frame_size("housekeeping", "pow")) # 38 bytes
         self.call_interval(100)
 
     def extract_raw_data(self):

--- a/FoGSE/read_raw_to_refined/readRawToRefinedPower.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedPower.py
@@ -5,12 +5,12 @@ the RTDs
 
 # `from PyQt6 import QtCore`
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
 
 from FoGSE.readBackwards import BackwardsReader
 from FoGSE.parsers.Powerparser import adcparser
 from FoGSE.collections.PowerCollection import PowerCollection
-
+from FoGSE.utils import get_frame_size, get_system_value
 
 class PowerReader(ReaderBase):
     """
@@ -26,7 +26,7 @@ class PowerReader(ReaderBase):
         ReaderBase.__init__(self, datafile, parent)
         
         self.define_buffer_size(size=get_frame_size("housekeeping", "pow")) # 38 bytes
-        self.call_interval(100)
+        self.call_interval(get_system_value("gse", "display_settings", "housekeeping", "pow", "read_raw_to_refined", "read_interval"))
 
     def extract_raw_data(self):
         """

--- a/FoGSE/read_raw_to_refined/readRawToRefinedRTD.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedRTD.py
@@ -5,12 +5,12 @@ the RTDs
 
 # `from PyQt6 import QtCore`
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
 
 from FoGSE.readBackwards import BackwardsReader
 from FoGSE.parsers.RTDparser import rtdparser
 from FoGSE.collections.RTDCollection import RTDCollection
-
+from FoGSE.utils import get_frame_size, get_system_value
 
 class RTDReader(ReaderBase):
     """
@@ -26,7 +26,7 @@ class RTDReader(ReaderBase):
         ReaderBase.__init__(self, datafile, parent)
         
         self.define_buffer_size(size=get_frame_size("housekeeping", "rtd")*2) # 84 bytes
-        self.call_interval(100)
+        self.call_interval(get_system_value("gse", "display_settings", "housekeeping", "rtd", "read_raw_to_refined", "read_interval"))
 
     def extract_raw_data(self):
         """

--- a/FoGSE/read_raw_to_refined/readRawToRefinedRTD.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedRTD.py
@@ -5,7 +5,7 @@ the RTDs
 
 # `from PyQt6 import QtCore`
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
 
 from FoGSE.readBackwards import BackwardsReader
 from FoGSE.parsers.RTDparser import rtdparser
@@ -24,8 +24,8 @@ class RTDReader(ReaderBase):
         Collected : organised by intrumentation
         """
         ReaderBase.__init__(self, datafile, parent)
-
-        self.define_buffer_size(size=84)
+        
+        self.define_buffer_size(size=get_frame_size("housekeeping", "rtd")*2) # 84 bytes
         self.call_interval(100)
 
     def extract_raw_data(self):

--- a/FoGSE/read_raw_to_refined/readRawToRefinedTimepix.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedTimepix.py
@@ -6,12 +6,12 @@ Can read:
     * Timepix
 """
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
 
 from FoGSE.readBackwards import BackwardsReader
 from FoGSE.parsers.Timepixparser import timepix_parser
 from FoGSE.collections.TimepixCollection import TimepixCollection
-
+from FoGSE.utils import get_frame_size, get_system_value
 
 class TimepixReader(ReaderBase):
     """
@@ -27,7 +27,7 @@ class TimepixReader(ReaderBase):
         ReaderBase.__init__(self, datafile, parent)
         
         self.define_buffer_size(size=5) # bytes, get_frame_size("timepix", "tpx")
-        self.call_interval(100)
+        self.call_interval(get_system_value("gse", "display_settings", "timepix", "tpx", "read_raw_to_refined", "read_interval"))
 
     def extract_raw_data(self):
         """

--- a/FoGSE/read_raw_to_refined/readRawToRefinedTimepix.py
+++ b/FoGSE/read_raw_to_refined/readRawToRefinedTimepix.py
@@ -6,7 +6,7 @@ Can read:
     * Timepix
 """
 
-from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase
+from FoGSE.read_raw_to_refined.readRawToRefinedBase import ReaderBase, get_frame_size
 
 from FoGSE.readBackwards import BackwardsReader
 from FoGSE.parsers.Timepixparser import timepix_parser
@@ -25,8 +25,8 @@ class TimepixReader(ReaderBase):
         Collected : organised by intrumentation
         """
         ReaderBase.__init__(self, datafile, parent)
-
-        self.define_buffer_size(size=5)
+        
+        self.define_buffer_size(size=5) # bytes, get_frame_size("timepix", "tpx")
         self.call_interval(100)
 
     def extract_raw_data(self):

--- a/FoGSE/utils.py
+++ b/FoGSE/utils.py
@@ -1,3 +1,8 @@
+""" Nothing going on here, just some JSON handling. """
+
+import json
+import os
+
 def get_system_dict(name: str, json_dict: dict):
     """
     Looks up the JSON `dict` in provided `json_dict`.
@@ -43,3 +48,71 @@ def get_ring_buffer_interface(json_dict):
             except KeyError:
                 continue
         return None
+    
+def _get_json_config():
+    """ A function to access the JSON configuration file. """
+    # get the JSON file with all settings
+    FILE_DIR = os.path.dirname(os.path.realpath(__file__))
+    json_config_file = os.path.join(FILE_DIR, "..", "foxsi4-commands", "systems.json")
+
+    # open the JSON file and find the system's product byte size
+    with open(json_config_file, "r") as json_config:
+        return json.load(json_config)
+
+def get_frame_size(system, product):
+    """
+    Method to retreive the "ring_frame_size_bytes" value for a given `system` 
+    (e.g., cdte1, cmos1, etc.) and `product` (e.g., pc, hk, etc.).
+
+    Parameters
+    ----------
+    system : `str`
+        The system of interest (e.g., cdte1, cmos1, etc.).
+
+    product : `str`
+        The system's product of interest (e.g., pc, hk, etc.).
+
+    Example
+    -------
+    >>> get_frame_size("cdte1", "pc")
+
+    32780 # the number of bytes to a cdte1_pc frame in the ring buffer
+
+    # same as running:
+    # int(get_system_dict("cdte1",json_dict)["spacewire_interface"]["ring_buffer_interface"]["pc"]["ring_frame_size_bytes"], 16)
+    """
+    return int(get_ring_buffer_interface(get_system_dict(system,_get_json_config()))[product]["ring_frame_size_bytes"], 16)
+    
+def get_system_value(system, *args):
+    """
+    Method to retreive the "ring_frame_size_bytes" value for a given `system` 
+    (e.g., cdte1, cmos1, etc.) and `product` (e.g., pc, hk, etc.).
+
+    Parameters
+    ----------
+    system : `str`
+        The system of interest (e.g., cdte1, cmos1, etc.).
+
+    *args : `str`
+        The system's keys to get the value needed (e.g., pc, hk, etc.).
+
+    Example
+    -------
+    >>> int(get_system_value("cdte1", "spacewire_interface", "ring_buffer_interface", "pc", "ring_frame_size_bytes"), 16)
+
+    32780 # the number of bytes to a cdte1_pc frame in the ring buffer
+
+    # same as running:
+    # `int(get_system_dict("cdte1",json_dict)["spacewire_interface"]["ring_buffer_interface"]["pc"]["ring_frame_size_bytes"], 16)`
+    # or `get_frame_size("cdte1", "pc")`
+    """
+    sys_dict = get_system_dict(system,_get_json_config())
+
+    # if there are no `args` then just want the system dictionary
+    if len(args)==0: return sys_dict
+
+    # now hunt down the value needed
+    _output = sys_dict[args[0]]
+    for a in args[1:]:
+        _output = _output[a]
+    return _output


### PR DESCRIPTION
# A PR for FOXSI-4's GSE <span>&#129418;</span>

***

_First and foremost, thank you so much for opening a PR for this repository. Any contribution is greatly appreciated._

> [!Note]
> _To make this process as easy as possible to follow when looking over and discussing the PR, please respond to each field below._
>
> _The fields below should inform the reader of the purpose(s) for the PR without having to infer things from the code itself._

## What is reason for this PR

* [ ] _Bug fix_
* [ ] _New feature_
* [x] _Behavioural change_
* [x] _Other_
  * Cleaning code and a breaking change

### Describe why the PR is needed

_For example, what problem is being tackled? What new behaviour is needed?_

A lot of values specific to each system was hard-coded into the GSE. These values should really be taken from one source and that should be [foxsi4-commands](https://github.com/foxsi/foxsi4-commands/tree/main).

### Please provide a description of the changes/additions being made to the package

_Although the changes in the code can be clear, try to describe the conceptial changes being made to the repository._

Just adding in functions that look up the JSON table from the foxsi4-commands package for the values needed in the GSE. This mainly only includes the frame sizes for each system.

### Are there any dangers in this change

_In a perfect, flawless, ideal, faultless world all changes would be without danger and never have any knock-on effects; however, sadly, our world is not perfect, flawless, ideal, or faultless._ <span>&#128532;</span>

_The PR could be introducing breaking changes which may seem to be resolved by the time of this PR. However, here is a good space to lay out what those breaking changes were and how they were resolved, as well as to highlight any change for future alterations/tests/features._

This links the repo to foxsi4-commands directly. This means that, unlike previous versions, both packages need to be installed rater than just the GSE.
