### PR TITLE
Removed the line that will try to replace 0s with nans, no need for t…

### DIFF
--- a/FoGSE/windows/TimepixWindow.py
+++ b/FoGSE/windows/TimepixWindow.py
@@ -93,8 +93,8 @@ class TimepixWindow(BaseWindow):
         new_flux = self.reader.collection.get_flux()
         
         # defined how to add/append onto the new data arrays
-        self.mean_tot.add_plot_data(new_mean_tot, replace={"this":[0], "with":[np.nan]})
-        self.flux.add_plot_data(new_flux, replace={"this":[0], "with":[np.nan]})
+        self.mean_tot.add_plot_data(new_mean_tot)
+        self.flux.add_plot_data(new_flux)
 
         # plot the newly updated x and ys
         self.mean_tot.manage_plotting_ranges()


### PR DESCRIPTION
An error was seen when Timepix data dropped during the first day of the campaign (yesterday, April 9). The erroneous data was not plotted properly.

Before
<img width="294" alt="Screenshot 2024-04-10 at 10 35 06" src="https://github.com/foxsi/GSE-FOXSI-4/assets/43237137/aaf88acc-8a7a-48a4-9b40-2e29b0ad6f13">

After
<img width="294" alt="Screenshot 2024-04-10 at 10 26 32" src="https://github.com/foxsi/GSE-FOXSI-4/assets/43237137/a2d90b3c-1c60-4caa-8f88-c544c16be505">

