### PR TITLE
Updates to logger to support frame counting

### DIFF
--- a/FoGSE/gse.py
+++ b/FoGSE/gse.py
@@ -1,7 +1,7 @@
 """
 First go at a full GSE (data viewing only).
 """
-import os
+import os, sys
 from PyQt6 import QtGui
 from PyQt6.QtWidgets import QApplication, QWidget, QGridLayout, QVBoxLayout
 
@@ -17,11 +17,14 @@ def get_det_file(want_filename, filename_list):
     return ""
 
 if __name__=="__main__":
+    config_file = None
+    if len(sys.argv) == 2:
+        config_file = sys.argv[1]
     app = QApplication([])
     icon_path = os.path.join(os.path.dirname(__file__), '..', 'assets', 'FOXSI4_32.png')
     app.setWindowIcon(QtGui.QIcon(icon_path))
     
-    glc = CommandUplinkWidget()
+    glc = CommandUplinkWidget(configuration=config_file)
     glc.show()
 
     w = GSEDataDisplay()

--- a/FoGSE/readers/PingReader.py
+++ b/FoGSE/readers/PingReader.py
@@ -1,0 +1,104 @@
+"""
+Create a class that will read the LOG file containing raw binary data received from 
+Formatter Ping messages
+"""
+
+from FoGSE.readers.BaseReader import BaseReader
+
+from FoGSE.readBackwards import BackwardsReader
+from FoGSE.telemetry_tools.parsers.Pingparser import pingparser
+from FoGSE.telemetry_tools.collections.PingCollection import PingCollection
+from FoGSE.utils import get_frame_size, get_system_value
+
+class PingReader(BaseReader):
+    """
+    Reader for Formatter Ping messages.
+    """
+
+    def __init__(self, datafile, parent=None):
+        """
+        Raw : binary
+        Parsed : human readable
+        Collected : organised by intrumentation
+        """
+        BaseReader.__init__(self, datafile, parent)
+        
+        self.define_buffer_size(size=get_frame_size("housekeeping", "ping")) # 46 bytes
+        self.call_interval(get_system_value("gse", "display_settings", "housekeeping", "pow", "readers", "read_interval"))
+
+    def extract_raw_data(self):
+        """
+        Method to extract the data from `self.data_file` and return the 
+        desired data.
+        """
+        return self.extract_raw_data_ping()
+    
+    def extract_raw_data_ping(self):
+        """
+        Method to extract the Ping data from `self.data_file` and return the 
+        desired data.
+        """
+        # read the file `self.bufferSize` bytes from the end and extract the lines
+        # forward=True: reads buffer from the back but doesn't reverse the data 
+        try:
+            with BackwardsReader(file=self.data_file, blksize=self.buffer_size, forward=True) as f:
+                datalist = f.read_block()
+
+            if self._old_data==datalist:
+                return self.return_empty() 
+        except FileNotFoundError:
+            return self.return_empty() 
+        
+        self._old_data = datalist
+        return datalist
+
+    def raw_2_parsed(self, raw_data):
+        """
+        Method to check if there is enough data in the file to continue.
+
+        Parameters
+        ----------
+        raw_data : list of strings
+            The lines from the content of `self.data_file` obtained using 
+            `FoGSE.readBackwards.BackwardsReader`.
+
+        Returns
+        -------
+        `tuple` :
+            Output from the parser.
+        """
+        # return or set human readable data
+        # do stuff with the raw data and return nice, human readable data
+        try:
+            output, error_flag = pingparser(raw_data)
+        except ValueError:
+            # no data from parser so pass nothing on with a time of -1
+            print("No data from Pingparser.")
+            output, error_flag = ({'unixtime':None, 'global_errors_int': None,
+                                   0:None, 1:None, 2:None, 3:None, 4:None, 5:None, 6:None, 7:None, 
+                                   8:None, 9:None, 10:None, 11:None, 12:None, 13:None, 14:None, 15:None},
+                                   None)
+        return output, error_flag
+
+    def parsed_2_collection(self, parsed_data):
+        """
+        Method to move the parsed data to the relevant collection.
+
+        Parameters
+        ----------
+        parsed_data : `tuple`
+            Output from the Ping parser.
+
+        Returns
+        -------
+        `FoGSE.telemetry_tools.collections.PingCollection.PingCollection` :
+            The Ping collection.
+        """
+        # take human readable and convert and set to 
+        # CdTeCollection(), TimePixCollection(), CMOSCollection()
+        col = PingCollection(parsed_data, self.old_data_time)
+        # if col.last_data_time>self.old_data_time:
+        #     self.old_data_time = col.last_data_time
+        # if not hasattr(self,"data_start_time"):
+        #     self.data_start_time = col.output['unixtime'][0]
+        return col

--- a/FoGSE/widgets/CommandUplinkWidget.py
+++ b/FoGSE/widgets/CommandUplinkWidget.py
@@ -1,4 +1,4 @@
-import sys, os, pathlib, platform
+import sys, os, pathlib, platform, time
 
 from PyQt6.QtWidgets import QWidget, QGroupBox, QVBoxLayout, QGridLayout, QComboBox, QLabel, QPushButton, QApplication, QMainWindow, QRadioButton, QButtonGroup, QLineEdit, QListWidget, QMessageBox, QSizePolicy
 from PyQt6 import QtCore, QtGui
@@ -9,17 +9,25 @@ from FoGSE.widgets import QValueWidget
 
 class CommandUplinkWidget(QWidget):
     """
-    `CommandUplinkWidget` provides a unified interface to send any uplink commands to the Formatter. This is enabled by `communication.FormatterUDPInterface`, which handles the socket I/O. The widget is laid out horizontally on the screen and provides a series of dropdown menus used to build up a valid command bitstring.
+    `CommandUplinkWidget` provides a unified interface to send any
+    uplink commands to the Formatter. This is enabled by
+    `communication.FormatterUDPInterface`, which handles the socket I/O.
+    The widget is laid out horizontally on the screen and provides a
+    series of dropdown menus used to build up a valid command bitstring.
 
-    Commands display in black by default, or in the color defined by FoGSE.communication.UplinkCommand.color. The current color coding is:
-    - if a command can cause issues that are not revertable by a subsystem power cycle (hardware damage, software issues beyond reboot, or data loss), it is colored red.
-    - CMOS enable_double_cmds are colored orange.
+    Commands display in black by default, or in the color defined by
+    FoGSE.communication.UplinkCommand.color. The current color coding
+    is: - if a command can cause issues that are not revertable by a
+    subsystem power cycle (hardware damage, software issues beyond
+    reboot, or data loss), it is colored red. - CMOS enable_double_cmds
+    are colored orange.
 
     :param name: Unique name of this panel interface.
     :type name: str
     :param label: Label for this interface (for display).
     :type label: str
-    :param cmddeck: Command deck object (instantiated using .json config files), used for command validation and filtering.
+    :param cmddeck: Command deck object (instantiated using .json config
+        files), used for command validation and filtering.
     :type cmddeck: communication.UplinkCommandDeck
     :param fmtrif: Formatter UDP interface object.
     :type fmtrif: communication.FormatterUDPInterface
@@ -32,12 +40,16 @@ class CommandUplinkWidget(QWidget):
         self.label = "Global command uplink"
 
         # build and validate list of allowable uplink commands
-        # self.cmddeck = comm.UplinkCommandDeck("config/all_systems.json", "config/all_commands.json")
-        # self.cmddeck = comm.UplinkCommandDeck("foxsi4-commands/all_systems.json", "foxsi4-commands/commands.json")
+        # self.cmddeck =
+        # comm.UplinkCommandDeck("config/all_systems.json",
+        # "config/all_commands.json") self.cmddeck =
+        # comm.UplinkCommandDeck("foxsi4-commands/all_systems.json",
+        # "foxsi4-commands/commands.json")
         
 
-        # open UDP socket to remote
-        # self.fmtrif = comm.FormatterUDPInterface(addr="127.0.0.1", port=9999, logging=True, logfilename=None)
+        # open UDP socket to remote self.fmtrif =
+        # comm.FormatterUDPInterface(addr="127.0.0.1", port=9999,
+        # logging=True, logfilename=None)
         if formatter_if is None:
             if configuration is not None:
                 self.fmtrif = comm.FormatterUDPInterface(configfile=configuration)
@@ -68,8 +80,8 @@ class CommandUplinkWidget(QWidget):
         self.command_label = QLabel("Command")
         self.command_combo_box = QListWidget()
         self.command_combo_box.setStyleSheet(f'font-size: 14pt; font-family: {platform_monospace}')
-        # self.args_label = QLabel("Argument")
-        # self.command_args_text = QLineEdit()
+        # self.args_label = QLabel("Argument") self.command_args_text =
+        # QLineEdit()
         self.send_label = QLabel("")
         self.command_send_button = QPushButton("Send command")
 
@@ -115,9 +127,11 @@ class CommandUplinkWidget(QWidget):
         system_basewidth = 80
         baseheight = self.system_combo_box.rectForIndex(self.system_combo_box.indexFromItem(self.system_combo_box.item(0))).height()
 
-        # for i in range(self.system_combo_box.count()):
-        #     if self.system_combo_box.item(i).text() == 'timepix' or self.system_combo_box.item(i).text() == 'saas':
-        #         self.system_combo_box.item(i).setSizeHint(QtCore.QSize(system_basewidth, 2*baseheight))
+        # for i in range(self.system_combo_box.count()): if
+        #     self.system_combo_box.item(i).text() == 'timepix' or
+        #         self.system_combo_box.item(i).text() == 'saas':
+        #         self.system_combo_box.item(i).setSizeHint(QtCore.QSize(system_basewidth,
+        #         2*baseheight))
 
         # for cmd in self.cmddeck[].commands:
         #     self.command_combo_box.addItem(cmd.name)
@@ -293,8 +307,8 @@ class CommandUplinkWidget(QWidget):
         self._working_command = [sys.addr,cmd.hex]
 
         if cmd.arg_len > 0:
-            # self.command_args_text.setEnabled(True)
-            # todo: some arg validation set up here. Implement in UplinkCommandDeck.
+            # self.command_args_text.setEnabled(True) todo: some arg
+            # validation set up here. Implement in UplinkCommandDeck.
             pass
         else:
             self.command_send_button.setEnabled(True)
@@ -335,8 +349,9 @@ class CommandUplinkWidget(QWidget):
         dialog.setMinimumHeight(500)
         if choice == QMessageBox.StandardButton.Ok:
             print("stopping listen process")
+            self.fmtrif.unix_local_socket.send(bytes([0x00,0xff])) # Dump message to listen process
+            time.sleep(0.5)
             self.fmtrif.background_listen_process.terminate()
-            # time.sleep(1)
             return event.accept()
         event.ignore()
 
@@ -390,8 +405,9 @@ if __name__ == "__main__":
     print(icon_path)
     app.setWindowIcon(QtGui.QIcon(icon_path))
 
-    # c = comm.FormatterUDPInterface(configfile="foxsi4-commands/foxsimile_systems.json", command_interface="uplink")
-    # c = comm.FormatterUDPInterface()
+    # c =
+    # comm.FormatterUDPInterface(configfile="foxsi4-commands/foxsimile_systems.json",
+    # command_interface="uplink") c = comm.FormatterUDPInterface()
     # window = CommandUplinkWidget(formatter_if=c)
     if len(sys.argv) == 2:
         window = CommandUplinkWidget(configuration=sys.argv[1])

--- a/FoGSE/widgets/CommandUplinkWidget.py
+++ b/FoGSE/widgets/CommandUplinkWidget.py
@@ -386,6 +386,9 @@ def platform_specific_monospace():
 if __name__ == "__main__":
     # if (len(sys.argv)) > 0:
     app = QApplication([])
+    icon_path = os.path.join(os.path.dirname(__file__), '..', '..', 'assets', 'FOXSI4_32.png')
+    print(icon_path)
+    app.setWindowIcon(QtGui.QIcon(icon_path))
 
     # c = comm.FormatterUDPInterface(configfile="foxsi4-commands/foxsimile_systems.json", command_interface="uplink")
     # c = comm.FormatterUDPInterface()

--- a/FoGSE/widgets/CommandUplinkWidget.py
+++ b/FoGSE/widgets/CommandUplinkWidget.py
@@ -105,9 +105,19 @@ class CommandUplinkWidget(QWidget):
         self.indicator_label = QValueWidget.QValueTimeWidget("", False, 250, parent=self, separator="", condition={"acceptable":[(True,"green"), (False,"red")]})
 
         # populate dialogs with valid lists:
-        for sys in self.cmddeck.systems:
+        for i, sys in enumerate(self.cmddeck.systems):
             if len(self.cmddeck.get_commands_for_system(sys.name)) != 0:
                 self.system_combo_box.addItem(sys.name.lower())
+        
+        self.system_combo_box.addItem('saas')
+        self.system_combo_box.addItem('formatter')
+
+        system_basewidth = 80
+        baseheight = self.system_combo_box.rectForIndex(self.system_combo_box.indexFromItem(self.system_combo_box.item(0))).height()
+
+        # for i in range(self.system_combo_box.count()):
+        #     if self.system_combo_box.item(i).text() == 'timepix' or self.system_combo_box.item(i).text() == 'saas':
+        #         self.system_combo_box.item(i).setSizeHint(QtCore.QSize(system_basewidth, 2*baseheight))
 
         # for cmd in self.cmddeck[].commands:
         #     self.command_combo_box.addItem(cmd.name)
@@ -118,7 +128,7 @@ class CommandUplinkWidget(QWidget):
             0,0,1,2,
             alignment=QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignTop
         )
-        self.system_combo_box.setMinimumWidth(160)
+        self.system_combo_box.setMinimumWidth(system_basewidth)
         self.system_combo_box.setMinimumHeight(min_scroll_height)
         self.system_combo_box.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Maximum)
         self.grid_layout.addWidget(

--- a/tests/network/packet_loser.py
+++ b/tests/network/packet_loser.py
@@ -1,0 +1,70 @@
+"""
+Get in loser. We're dropping packets.
+
+This is an (un)helpful (dis)utility to ingest downlink packets and
+randomly drop some of them. Can use to stress-test the logging
+capability of the GSE.
+
+You may need to mess with addresses in `foxsi4-commands/systems.json` to
+get this to be useful. One way to do this would be to change
+`systems.json`'s Ethernet address property for the gse system:
+    gse.ethernet_interface.address : "127.0.0.120"
+And to delete the line
+    "mcast_group": "224.1.1.118"
+from `system.json`. So the resultant "gse" block would contain this
+"ethernet_interface":
+
+.. code-block:: json
+
+    "ethernet_interface": {
+            "protocol": "udp", "address": "127.0.0.120", "port": 9999,
+            "max_payload_bytes": 2000
+        },
+
+Then run `packet_loser.py` like this:
+    > python packet_loser.py 224.1.1.118 9999 127.0.0.120 9999 0.3333
+
+This will get `packet_loser.py` to listen on the usual downlink
+broadcast IP and port: 224.1.1.118:9999, drop 1/3 packets randomly, and
+retransmit to the local IP address and port 127.0.0.120:9999.
+
+If you then launch the GSE with your modified
+`foxsi4-commands/systems.json` file (which sets the GSE address to )
+"""
+
+import sys, socket, random, ipaddress, struct
+
+if __name__ == "__main__":
+    if len(sys.argv) != 6:
+        print("use like this:\n\t> python packet_loser.py listen-ip listen-port send-ip send-port drop-rate")
+        sys.exit(1)
+    
+    listen_addr = sys.argv[1]
+    listen_port = int(sys.argv[2])
+    forward_addr = sys.argv[3]
+    forward_port = int(sys.argv[4])
+
+    intermediate_addr = "127.0.0.1"
+
+    drop_odds = float(sys.argv[5])
+
+    if ipaddress.IPv4Address(listen_addr).is_multicast:
+        listen_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+        listen_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+
+        listen_sock.bind((listen_addr, listen_port))
+        if not ipaddress.IPv4Address(forward_addr).is_multicast:
+            mreq = struct.pack('4s4s', socket.inet_aton(listen_addr), socket.inet_aton(forward_addr))
+        else:
+            mreq = struct.pack('4s4s', socket.inet_aton(listen_addr), socket.inet_aton(intermediate_addr))
+
+        listen_sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+    else:
+        listen_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        listen_sock.bind((listen_addr, listen_port))
+
+    print('listening...')
+    while True:
+        data, sender = listen_sock.recvfrom(4096)
+        if random.random() > drop_odds:
+            listen_sock.sendto(data, (forward_addr, forward_port))

--- a/tests/network/power_send.py
+++ b/tests/network/power_send.py
@@ -1,0 +1,34 @@
+"""
+A simple script to regurgitate logged housekeeping_pow packets back to a remote IP address for testing.
+"""
+
+
+import socket, sys, time
+
+def chunks(lst, n):
+    """Yield successive n-sized chunks from lst."""
+    for i in range(0, len(lst), n):
+        yield lst[i:i + n]
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("use like this:\n\t> python power_send.py path/to/housekeeping_pow.log")
+        sys.exit(1)
+    
+    local_addr = "127.0.0.1"
+    local_port = 9999
+    send_addr = "224.1.1.118"
+    send_port = 9999
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind((local_addr, local_port))
+    
+    with open(sys.argv[1], 'rb') as file:
+        data = file.read()
+
+    print('sending...')
+    prefix = bytes([0x02, 0x00, 0x01, 0x00, 0x01, 0x11, 0x00, 0x00])
+    for chunk in chunks(data, 0x26):
+        print("sending", (prefix + chunk).hex())
+        sock.sendto(prefix + chunk, (send_addr,send_port))
+        time.sleep(0.5)


### PR DESCRIPTION
# A PR for FOXSI-4's GSE <span>&#129418;</span>

## What is reason for this PR

* [x] _Bug fix_
* [x] _New feature_
* [x] _Behavioural change_
* [ ] _Other_

### First, some context

FOXSI downlink data for, e.g., CdTe and CMOS photon counting, comes in very large _frames_. A frame must be broken up into _packets_ for downlink. The logging functionality of the GSE (contained in [`FoGSE/listening.py`](https://github.com/foxsi/GSE-FOXSI-4/blob/main/FoGSE/listening.py)) is responsible for reassembling received _packets_ into complete _frames_. 

Packets are given an 8-byte header by the Formatter, which looks like this:
| Byte(s) | Description |
|---------|-------------|
| `0`     | A code describing the system that produced the data in the packet |
| `1`-`2` | The total number of packets that make up a complete frame |
| `3`-`4` | The index of this packet in the frame. **NOTE: THIS IS INDEXED FROM 1, not 0!** |
| `5`     | A code describing the type of data in this packet (e.g. photon-counting vs. general housekeeping vs. power etc.) |
| `6`-`7` | _Up until this PR these were reserved bytes, the Formatter just set them to zero, and the logger ignored them._ |

The logger (contained in [`FoGSE/listening.py`](https://github.com/foxsi/GSE-FOXSI-4/blob/main/FoGSE/listening.py)), up to this PR, has rebuilt complete frames from packets by the following process:

![old_logging_logic](https://github.com/user-attachments/assets/a89571f4-3a2a-459b-a39d-efd9e1c59931)

This logic is vulnerable to a case where the first $n$ packets of a frame (call it frame $f_0$) are dropped in the downlink. In this scenario, the first $n$ packets from the subsequent transmitted frame (call it $f_1$) will be erroneously substituted into $f_0$, and same for all following frames. This introduces a constant packet offset, occurring partway through logged frames, in all logged data of a given type.

This occurred during the FOXSI-4 flight. This is possible to fix in post by examining TI clock values for CdTe event data, but is harder to correct in CMOS. 

This PR supports a new field in the downlink packet header that will help mitigate packet loss issues in the downlink stream.

### Changes

[Formatter PR 75](https://github.com/foxsi/foxsi-4matter/pull/75) proposes using the previously reserved bytes `6`-`7` in the downlink packet header as a **frame counter**:
| Byte(s) | Description |
|---------|-------------|
| `6`-`7` | Proposed: 2-byte wide frame counter |

For large downlink frames which must be fragmented into packets for transmission, the formatter will now assign a `frame_counter` to each packet of a given data type and system. This `frame_counter` is the same for _all_ packets belonging to one source frame. After all those frame's packets are transmitted, that `frame_counter` will increment.

On the ground side, this PR modifies the downlink logging logic to:
1. Inspect the `frame_counter` field of each downlink packet header.
2. Create a new frame object if the `frame_counter` is new, to manage assembly of the frame from packets.
3. Insert packets into frames as before, with the additional condition that packets must insert in frames with matching packet number.

Here is a diagram of this logic:

![new_logging_logic](https://github.com/user-attachments/assets/23729210-ec45-459b-844e-3a5c1c47367f)

### Rollover

Using a 2-byte wide `frame_counter` gives `0xffff = 65,535` possible values before the counter rolls over. The formatter main loop runs with a period of ~1.5 s, so it will take $1.5 \times 65,535$ seconds, or ~27 hours, of continuous operation for the counter to roll over. Hopefully that doesn't happen. As an aside, I considered using only one byte for this counter, but that would roll over in ~6 minutes.

### Dangers

As currently implemented, the new logger will never dump incomplete frames to disk. Frames are only written to disk when they are complete, and in a lossy downlink with this new logger we would lose (wholesale) the frames whose packets have been lost. 

We should consider if this is the behavior we want. A possibility is to use one of the PyQt `closeEvent` callbacks to dump any remaining incomplete frames to disk.

#### Send old packets to the new logger
Every old-style packet has `0x00` in the `frame_counter` field. So the new logger will try to put these all into the same frame. If there is no packet loss, the old logger will write exactly the same data to file as the new logger. 

I have run both old and new loggers simultaneously, broadcast the same old-style Formatter packets to both, and both logs are identical.

#### Sending new packets to the old logger
The old logger completely ignored packet header bytes `6`-`7`, where the new `frame_counter` field is. If there is no packet loss, the old logger will write exactly the same data to file as the new logger. 

I have run both old and new loggers simultaneously, broadcast the same new-style Formatter packets to both, and both logs are identical.