### PR TITLE
Gse spacing

### DIFF
--- a/FoGSE/gse.py
+++ b/FoGSE/gse.py
@@ -30,7 +30,7 @@ if __name__=="__main__":
     w = GSEDataDisplay()
 
     _s = 122
-    w.setGeometry(0,0, 12*_s, 8*_s) # 12 to 8
+    w.setGeometry(0,0, int(13.7*_s), int(8*_s)) # 12 to 8
     w.setStyleSheet("border-width: 2px; border-style: outset; border-radius: 10px; border-color: white; background-color: rgba(238, 186, 125, 150);")
 
     w.show()

--- a/FoGSE/gse_data_display.py
+++ b/FoGSE/gse_data_display.py
@@ -75,11 +75,11 @@ class GSEDataDisplay(QWidget):
 
         lay = QGridLayout()
 
-        lay.addWidget(self.f0, 0, 0, 3, 12)
-        lay.addWidget(self.f1, 3, 0, 3, 12)
-        lay.addWidget(self.f2, 6, 0, 2, 4)
-        lay.addWidget(self.f3, 6, 4, 2, 4)
-        lay.addWidget(self.f4, 6, 8, 2, 4)
+        lay.addWidget(self.f0, 0, 0, 6, 24)
+        lay.addWidget(self.f1, 6, 1, 6, 22)
+        lay.addWidget(self.f2, 12, 1, 4, 8)
+        lay.addWidget(self.f3, 12, 8, 4, 8)
+        lay.addWidget(self.f4, 12, 15, 4, 8)
         
         # w.resize(1000,500)
         # _s = 122
@@ -211,7 +211,7 @@ if __name__=="__main__":
     w = GSEDataDisplay(window_alert=True)
 
     _s = 122
-    w.setGeometry(0,0, 14*_s, 8*_s) # 14 to 8
+    w.setGeometry(0,0, int(13.7*_s), int(8*_s)) # 14 to 8
     w.setStyleSheet("border-width: 2px; border-style: outset; border-radius: 10px; border-color: white; background-color: rgba(238, 186, 125, 150);")
 
     w.show()

--- a/FoGSE/playback/gse_data_display_playback.py
+++ b/FoGSE/playback/gse_data_display_playback.py
@@ -42,7 +42,7 @@ if __name__=="__main__":
     w = GSEPlaybackDataDisplay(window_alert=True)
 
     _s = 122
-    w.setGeometry(0,0, 14*_s, 8*_s) # 14 to 8
+    w.setGeometry(0,0, int(13.7*_s), int(8*_s)) # 14 to 8
     w.setStyleSheet("border-width: 2px; border-style: outset; border-radius: 10px; border-color: white; background-color: rgba(238, 186, 125, 150);")
 
     w.show()


### PR DESCRIPTION
We can chat about the usefulness of this PR.

Changes have been made in the past that has made the different data displays change aspect ratio. This PR aims to make the GSE look a little more sensible.

This PR also includes the changes made in #89 that updates the Timepix display. The only files this PR changes on top of that are:

- FoGSE/playback/gse_data_display_playback.py 
  - `w.setGeometry(0,0, 12*_s, 8*_s)` to `w.setGeometry(0,0, int(13.7*_s), int(8*_s))` to avoid strip of empty space to the right of the display
- FoGSE/gse.py
  - same as above
- FoGSE/gse_data_display.py
  - same as above
  - and I increased the layout grid for the widgets so I could move the middle and bottom rows into the middle of the display with more control (see difference in images below)

Old:
<img width="1820" height="1116" alt="Screenshot 2026-03-11 at 4 46 51 pm" src="https://github.com/user-attachments/assets/695d4e54-2f4b-4632-b909-ad8dd016e26e" />

New:
<img width="1783" height="1116" alt="Screenshot 2026-03-12 at 3 47 57 pm" src="https://github.com/user-attachments/assets/b1c75a3d-b055-4b9b-bf3d-6b493caa7b66" />

