### PR TITLE
A patch for frame counter issue, evident when downlink is very lossy

### DIFF
--- a/FoGSE/listening.py
+++ b/FoGSE/listening.py
@@ -223,7 +223,7 @@ class LogFileManager:
         datatype = raw_data[5]
         npackets = int.from_bytes(raw_data[1:3], byteorder='big')
         ipacket = int.from_bytes(raw_data[3:5], byteorder='big')
-        iframe = raw_data[7]
+        iframe = int.from_bytes(raw_data[6:7], byteorder='big')
 
         if system != self.system:
             print("Log queue got bad system code!")


### PR DESCRIPTION
This is a fix candidate for the issue we see in streaky CMOS images.

Pre-PR, the GSE only checks the LSB of every downlink packet's frame counter to see if it is already constructing the frame on the ground. This PR corrects that to use the full 16-bit frame counter value. 

The current behavior of the GSE is to erroneously apply new packets to existing frames (because it is not using the full frame counter value of new packets), and therefor to prematurely write in-progress frames to disk. 

When telemetry is very lossy, these frames are unlikely to ever be completed, but that doesn't mean we should put incorrect data in the frames just to get them to write to disk.

Merging this PR would mean:
1. Less risk of pre-launch data appearing (incorrectly) on the GSE in the middle of flare observation data.
2. Less frequent GSE image (CdTe + CMOS) updates when telemetry is very lossy. HK updates to GSE will not be affected. 

@pymilo @KriSun95 