### PR TITLE
Add buttons to clear frame buffer

### DIFF
--- a/FoGSE/listening.py
+++ b/FoGSE/listening.py
@@ -280,13 +280,13 @@ class LogFileManager:
         outframe = self.pop_frame(frame_counter)
         self.file.write(outframe.data)
         self.file.flush()
-        print("wrote frame count " + str(frame_counter) + " to " + self.filepath)
+        # print("wrote frame count " + str(frame_counter) + " to " + self.filepath)
     
-    def dump(self):
-        for f in self.frames: 
-            self.dumpfile.write(f.data)
+    def dump(self, frame_counter:int):
+        # for f in self.frames: 
+        outframe = self.pop_frame(frame_counter)
+        self.dumpfile.write(outframe.data)
         self.dumpfile.flush()
-        self.dumpfile.close()
     
 class CurrentFrame():
     """
@@ -651,7 +651,32 @@ class Listener():
                     print("received Listener terminate message")
                     for system in self.downlink_lookup.keys():
                         for data in self.downlink_lookup[system].keys():
-                            self.downlink_lookup[system][data].dump()
+                            dump_counters = [f.get_frame_counter() for f in self.downlink_lookup[system][data].frames]
+                            for counter in dump_counters:
+                                self.downlink_lookup[system][data].dump(counter)
+                            self.downlink_lookup[system][data].dumpfile.close()
+                    return
+                elif data[0] == 0x00 and data[1] == 0xcb:
+                    # clear frame buffer to log folder, so you can see the results
+                    print("clearing frame buffers to log folder")
+                    for system in self.downlink_lookup.keys():
+                        for data in self.downlink_lookup[system].keys():
+                            pre_clear = len(self.downlink_lookup[system][data].frames)
+                            clear_counters = [f.get_frame_counter() for f in self.downlink_lookup[system][data].frames]
+                            for counter in clear_counters:
+                                self.downlink_lookup[system][data].write(counter)
+                            print("pre:", pre_clear, "post clear:", len(self.downlink_lookup[system][data].frames))
+                    return
+                elif data[0] == 0x00 and data[1] == 0xcd:
+                    # clear frame buffer to dump folder
+                    print("clearing frame buffers to dump folder")
+                    for system in self.downlink_lookup.keys():
+                        for data in self.downlink_lookup[system].keys():
+                            pre_clear = len(self.downlink_lookup[system][data].frames)
+                            dump_counters = [f.get_frame_counter() for f in self.downlink_lookup[system][data].frames]
+                            for counter in dump_counters:
+                                self.downlink_lookup[system][data].dump(counter)
+                            print("pre:", pre_clear, "post clear:", len(self.downlink_lookup[system][data].frames))
                     return
                 else:
                     self._uplink_message_queue.put([data[0], data[1]])

--- a/FoGSE/widgets/CommandUplinkWidget.py
+++ b/FoGSE/widgets/CommandUplinkWidget.py
@@ -90,6 +90,8 @@ class CommandUplinkWidget(QWidget):
         # QLineEdit()
         self.send_label = QLabel("")
         self.command_send_button = QPushButton("Send command")
+        self.flush_frame_buffer_button = QPushButton("Flush frames")
+        self.dump_frame_buffer_button = QPushButton("Dump frames")
 
         self._raw, self._check = "Raw: ", "Name: "
         self.system_raw_label = QLabel(self._raw, self)
@@ -225,6 +227,17 @@ class CommandUplinkWidget(QWidget):
             alignment=QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignTop
         )
         self.grid_layout.addWidget(
+            self.flush_frame_buffer_button,
+            2,4,1,2,
+            alignment=QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignBottom
+        )
+        self.grid_layout.addWidget(
+            self.dump_frame_buffer_button,
+            3,4,1,2,
+            alignment=QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignBottom
+        )
+        # self.dump_frame_buffer_button    
+        self.grid_layout.addWidget(
             self.command_interface_label,
             5,0,1,2,
             alignment=QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignTop
@@ -284,6 +297,9 @@ class CommandUplinkWidget(QWidget):
         self.system_combo_box.itemSelectionChanged.connect(self.systemComboBoxClicked)
         self.command_combo_box.itemSelectionChanged.connect(self.commandComboBoxClicked)
         self.command_send_button.clicked.connect(self.commandSendButtonClicked)
+        
+        self.flush_frame_buffer_button.clicked.connect(self.flushFramesButtonClicked)
+        self.dump_frame_buffer_button.clicked.connect(self.dumpFramesButtonClicked)
 
         self.power_reader.value_changed_collection.connect(self.powerUpdated)
         self.ping_reader.value_changed_collection.connect(self.pingUpdated)
@@ -356,6 +372,13 @@ class CommandUplinkWidget(QWidget):
 
         self.command_combo_box.setEnabled(True)
         self.command_send_button.setEnabled(False)
+    
+    def flushFramesButtonClicked(self, events):
+        print("flushing all frame buffers")
+        self.fmtrif.unix_local_socket.send(bytes([0x00,0xcb]))
+    def dumpFramesButtonClicked(self, events):
+        print("dumping all frame buffers")
+        self.fmtrif.unix_local_socket.send(bytes([0x00,0xcd]))
     
     def commandInterfaceButtonClicked(self, events):
         print("switched to commanding mode:", self.command_mode_button_group.checkedButton().text())

--- a/tests/network/send_frames.py
+++ b/tests/network/send_frames.py
@@ -1,0 +1,92 @@
+import sys, socket, random, ipaddress, struct, time
+
+structure = {
+    0x0e: {
+        0x00: {"length": 0x90400, "frame_counter": 0},
+        0x01: {"length": 0x78400, "frame_counter": 0}
+    },
+    0x0f: {
+        0x00: {"length": 0x90400, "frame_counter": 0},
+        0x01: {"length": 0x78400, "frame_counter": 0}
+    },
+    0x09: {
+        0x00: {"length": 0x800c, "frame_counter": 0}
+    },
+    0x0a: {
+        0x00: {"length": 0x800c, "frame_counter": 0}
+    },
+    0x0b: {
+        0x00: {"length": 0x800c, "frame_counter": 0}
+    },
+    0x0c: {
+        0x00: {"length": 0x800c, "frame_counter": 0}
+    }
+}
+
+def chunks(lst, n):
+    """Yield successive n-sized chunks from lst."""
+    for i in range(0, len(lst), n):
+        yield lst[i:i + n]
+
+max_payload = 1440
+
+def make_packets(system:int, data:int):
+    counter_value = structure[system][data]["frame_counter"]
+    counter_value = counter_value & 0xffff # wrap to 16 bits
+    
+    # put the 16-bit counter as the payload of the whole frame, repeating.
+    frame = [(counter_value >> 8) & 0xff if k % 2 == 0 else counter_value & 0xff for k in range(structure[system][data]["length"])]
+    # frame = [0x01 if counter_value % 2 == 0 else 0x10 for k in range(structure[system][data]["length"])]
+    total_packets = -(-structure[system][data]["length"] // max_payload)
+    
+    packets = []
+    # print(chunks(frame, max_payload))
+    for k,p in enumerate(chunks(frame, max_payload)):
+        header = [
+            system & 0xff, 
+            (total_packets >> 8) & 0xff, total_packets & 0xff,
+            ((k+1) >> 8) & 0xff, (k+1) & 0xff,
+            data & 0xff,
+            (counter_value >> 8) & 0xff, counter_value & 0xff
+        ]
+        header.extend(p)
+        # put the header on this packet, then put the whole thing in the list of packets.
+        packets.append(header)
+    structure[system][data]["frame_counter"] = 1 + structure[system][data]["frame_counter"]
+    return packets
+
+if __name__ == "__main__":
+    if len(sys.argv) != 5:
+        print("use like this:\n\t> python send_frames.py local-ip local-port send-ip send-port")
+        sys.exit(1)
+    
+    local_addr = sys.argv[1]
+    local_port = int(sys.argv[2])
+    forward_addr = sys.argv[3]
+    forward_port = int(sys.argv[4])
+    
+    intermediate_addr = "127.0.0.1"
+    
+    if ipaddress.IPv4Address(local_addr).is_multicast:
+        listen_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+        listen_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+
+        listen_sock.bind((local_addr, local_port))
+        # if ipaddress.IPv4Address(forward_addr).is_multicast:
+        #     mreq = struct.pack('4s4s', socket.inet_aton(local_addr), socket.inet_aton(intermediate_addr))
+        #     listen_sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+
+    else:
+        listen_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        listen_sock.bind((local_addr, local_port))
+
+    print('listening...')
+    while True:
+        for system in structure.keys():
+            for data in structure[system].keys():
+                
+                packets = make_packets(system, data)
+                print("system", hex(system), "type", hex(data), "\033[0;1mframe count", hex(structure[system][data]["frame_counter"]), "\033[0msending", len(packets), "packets")
+                for packet in packets:
+                    listen_sock.sendto(bytes(packet), (forward_addr, forward_port))
+                time.sleep(0.25)


### PR DESCRIPTION
This is another fix candidate (alongside #92) for the issue we see in streaky CMOS images.

The current behavior of the GSE is to erroneously apply new packets to existing frames (because it is not using the full frame counter value of new packets), and therefore to prematurely write in-progress frames to disk.

When telemetry is very lossy, these frames are unlikely to ever be completed and are pushed onto the disk by the arrival of packets 9-18 minutes later (9 minutes for CdTe PC, 18 minutes for CMOS PC and QL).

Merging this PR would mean:
- Options for the GSE operator to clear incomplete data out of the GSE frame buffers (either pre-launch, or in flight immediately before observation).
- This new functionality does not modify any of the code that records data to the disk (logging), nor does it interact with the Formatter at all.

This PR makes the command uplink window look like this:

<img width="797" height="806" alt="Screenshot 2026-05-04 at 3 30 42 PM" src="https://github.com/user-attachments/assets/a4ead897-41ee-4741-be38-23f340f440a9" />

The "Flush frames" button writes all incomplete frames to their log files, and the GSE will display the last frame in whatever state it is in (for visual feedback).

The "Dump frames" button writes all incomplete frames to the dump folder, which the GSE doesn't display. So there's no visual feedback. But the incomplete frame data is still retained so we can check it after the flight/after the GSE closes.